### PR TITLE
fix to update support objects and config file

### DIFF
--- a/lib/model/codeceptjs-factory.js
+++ b/lib/model/codeceptjs-factory.js
@@ -28,18 +28,28 @@ const loadRealtimeReporter = container => {
 
 
 module.exports = new class CodeceptjsFactory {
-  constructor() {}
+  constructor(configFile = 'codecept.conf.js') {
+    this.configFile = configFile;
+  }
 
   getInstance() {
     if (!instance) instance = this.create();
     return instance;
   }
 
+  getConfigFile() {
+    return this.configFile;
+  }
+
+  getRootDir() {
+    return TestProject;
+  }
+
   create(cfg = {}, opts = {}) {
     debug('Creating codeceptjs instance...');
 
     config.reset();
-    config.load(path.join(TestProject, 'codecept.conf.js'))
+    config.load(path.join(TestProject, this.configFile))
     config.append(cfg);
     cfg = config.get();
 

--- a/lib/model/scenario-repository.js
+++ b/lib/model/scenario-repository.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('codepress:scenario-repository');
-const path = require('path');
+const fsPath = require('path');
 const chokidar = require('chokidar');
 
 const throttled = require('../model/throttling');
@@ -57,9 +57,22 @@ chokidar.watch('./**/*.js', {
   followSymlinks: false,
   interval: 500
 }).on('all', throttled(500, (event, path) => {
-  debug('Scenarios have been updated', path);
+  debug('Scenarios have been updated', event, path);
+  
+  cleanupModule(path);
 
+  if (path === codeceptjsFactory.getConfigFile()) {
+    reloadConfig();
+  }
+  
+  const { config } = codeceptjsFactory.getInstance();
+  // if it is a support object => reinclude it
+  Object.entries(config.get('include'))
+    .filter(e => e[1] === fsPath.join(codeceptjsFactory.getRootDir(), path))
+    .forEach(e => cleanupSupportObject(e[0]));
+    
   try {
+    // reloadModule(path);  
     suites = codeceptjsFactory.reloadSuites();
     // codeceptjsFactory.reloadContainer();
 
@@ -82,8 +95,8 @@ const getFeatures = (searchQuery, opts = {}) => {
           orgTitle: suite.title,
         },
         file: suite.file,
-        fileBaseName: path.basename(suite.file),
-        fileRelDir: makeRelativePath(path.dirname(suite.file)),
+        fileBaseName: fsPath.basename(suite.file),
+        fileRelDir: makeRelativePath(fsPath.dirname(suite.file)),
         fileRelPath: makeRelativePath(suite.file),
         scenarios: [],
       };
@@ -117,6 +130,35 @@ const getScenario = (scenarioId) => {
     return features
         .map(f => f.scenarios.find(s => s.id === scenarioId))
         .filter(f => !!f)[0];
+}
+
+function reloadConfig() {
+  const { config, container } = codeceptjsFactory.getInstance();
+  config.reset();
+  config.load(codeceptjsFactory.getConfigFile());  
+  const helpersConfig = config.get('helpers');
+  for (const helperName in container.helpers()) {
+    if (helpersConfig[helperName]) {
+      container.helpers(helperName)._setConfig(helpersConfig[helperName]);
+    }
+  }
+
+  Object.keys(config.get('include')).forEach(s => cleanupSupportObject(s));
+
+  console.log('Updated config file. Refreshing...', )
+}
+
+function cleanupSupportObject(supportName) {
+  const { container, config } = codeceptjsFactory.getInstance();
+  const includesConfig = config.get('include');
+  if (!includesConfig[supportName]) return;
+  const support = container.support();
+  delete support[supportName];
+}
+
+function cleanupModule(moduleName){
+  moduleName = fsPath.join(codeceptjsFactory.getRootDir(), moduleName);
+  if (require.cache[require.resolve(moduleName)]) delete require.cache[require.resolve(moduleName)]
 }
 
 const groupFeaturesByCapability = features => {


### PR DESCRIPTION
* once a file is updated => unload it from require cache
* once config is updated => reload a config (helps easily switch between headless/window mode)
* once PO is updated => remove it from a container