### PR TITLE
fix: disable iframe updating history object

### DIFF
--- a/src/components/SnapshotSource.vue
+++ b/src/components/SnapshotSource.vue
@@ -3,12 +3,14 @@
         <div class="SnapshotSource-content has-background-grey-lighter">
             <iframe 
                 ref="source"
-                id="source" 
-                :src="buildSnapshotUrl(snapshotId)" 
+                id="source"  
+                :src="buildSnapshotUrl(snapshotId)"
+                :key="'codepress-iframe-'+buildSnapshotUrl(snapshotId)"
                 :width="viewportSize.width" 
                 frameborder="0"
                 @load="onIframeLoaded"
                 v-show="loaded"
+                sandbox="allow-scripts allow-same-origin"
             >
             </iframe>
         </div>
@@ -80,7 +82,6 @@ export default {
 
         onIframeLoaded() {
             this.loaded = true;
-
             if (this.mustScrollIframe()) {
                 // Only page to vertical position
                 this.$refs.source.contentWindow.scrollTo(0, this.$props.snapshotScrollPosition.y);

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ Vue.use(new VueSocketIO({
 Vue.config.productionTip = false
 
 const router = new VueRouter({
+  mode: 'history',
   routes
 });
 


### PR DESCRIPTION
Closes #34 

Changes made:

- Change Vue router mode from 'hash' to 'history'.
- Get Iframe src from variable and added a key attribute.
- Add sandbox attribute to iframe in order to provide the least privilege to iframe.

Solves :

- Browser back button first redirects to '#/' URL then the previous page.
- Multiple browser back button clicks needed to reach the previous page.