### PR TITLE
fix: clear previous selected step

### DIFF
--- a/src/components/TestRunPage.vue
+++ b/src/components/TestRunPage.vue
@@ -73,6 +73,7 @@ export default {
     }
   },
   created: async function () {
+    this.$store.commit('testRunPage/clearTests');
     await this.loadScenario();
     await this.loadLastTestRun(this.scenario);
   },


### PR DESCRIPTION
Closes #29 

Issue: Testrun page displays the selected step from the previous test run.
Fix: Clear previously set selectedStep in the created phase of the Testrun component.