### PR TITLE
Better look for steps

### DIFF
--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -25,19 +25,36 @@ const mapSuiteAndTest = (startedAt, suite, test) => {
     steps: [],
   }
 }
+const mapArgs = (args) => {
+  return args.map(a => {
+    if (typeof a === "function") return a.toString();
+    return a;
+  });
+}
+
 const mapMetaStep = (metaStep) => {
   if (!metaStep) return;
 
   return {
     actor: metaStep.actor,
-    name: metaStep.name
+    name: metaStep.name,
+    args: metaStep.args,
   }
 }
+
+const stringifyMetaStep = (metaStep, line = '') => {
+  if (!metaStep) return line;
+  line += `${metaStep.actor.replace(/[\W_]+/g, '') || ''}-${metaStep.name.replace(/[\W_]+/g, '') || ''}_`;
+  return stringifyMetaStep(metaStep.metaStep, line);
+}
+
 
 const isEqualMetaStep = (metastep1, metastep2) => {
   if (!metastep1 && !metastep2) return true;
   if (!metastep1 || !metastep2) return false;
-  return metastep1.actor === metastep2.actor && metastep1.name === metastep2.name;
+  return metastep1.actor === metastep2.actor 
+    && metastep1.name === metastep2.name 
+    && metastep1.args.join(',') === metastep2.args.join(',');
 }
 
 // eslint-disable-next-line no-undef
@@ -50,8 +67,6 @@ class RealtimeReporterHelper extends Helper {
   constructor(options) {
     super(options);
 
-    debug('constructor options', options);
-
     this.isConnected = false;
     this.stepIndex = 1;
     this.suite = undefined;
@@ -61,6 +76,8 @@ class RealtimeReporterHelper extends Helper {
     this.nextForceTakeSnapshot = undefined;
 
     event.dispatcher.on('step.comment', (msg) => {
+      // ignore metasteps as comment events
+      if (this.metaStep && `${this.metaStep.actor} ${this.metaStep.name}` == msg.trim()) return;
       wsEvents.rtr.stepComment({
         id: this.stepIndex++,
         at: Date.now() - this.testStartedAt,
@@ -101,7 +118,15 @@ class RealtimeReporterHelper extends Helper {
   }
 
   _getHelper() {
-    return this.helpers['Appium'] || this.helpers['Webdriver'] || this.helpers['Puppeteer'];
+    return this.helpers['Appium'] || this.helpers['WebDriver'] || this.helpers['WebDriverIO'] || this.helpers['Puppeteer'];
+  }
+
+  _generateSection(metaStep, append = false) {
+    if (!metaStep) return;
+    const line = stringifyMetaStep(metaStep);    
+    if (append) this.loggedMetaSteps.push(line);
+    const index = this.loggedMetaSteps.filter(ms => ms === line).length;
+    return line + index;
   }
 
   _mapStep({testStartedAt, id, step, snapshot, returnValue}) {
@@ -124,8 +149,9 @@ class RealtimeReporterHelper extends Helper {
       humanized: step.humanize(),
       humanizedArgs: step.humanizeArgs(),
       name: step.name,
-      args: step.args,
+      args: mapArgs(step.args),
       snapshot,
+      section: this._generateSection(step.metaStep),
       metaStep: mapMetaStep(step.metaStep),
       returnValue,
       stack
@@ -167,8 +193,14 @@ class RealtimeReporterHelper extends Helper {
 
   _emitMetaStepChangedIfNecessary() {
     if (!isEqualMetaStep(this.step.metaStep, this.metaStep)) {
+      // append changed metastep to list 
       // NOTE this.metaStep can be null which means "no metastep"
-      wsEvents.rtr.metaStepChanged(this.step.metaStep);
+      let section = '';
+      if (this.step.metaStep) {
+        if (this.step.metaStep.metaStep) section = this._generateSection(this.step.metaStep.metaStep);
+        const opens = this._generateSection(this.step.metaStep, true);
+        if (this.step.metaStep) wsEvents.rtr.metaStepChanged(Object.assign(this.step.metaStep, { opens, section }));
+      }
       this.metaStep = this.step.metaStep;
     }
   }
@@ -205,6 +237,7 @@ class RealtimeReporterHelper extends Helper {
     this.stepIndex = 0;
     this.step = undefined;
     this.metaStep = undefined;
+    this.loggedMetaSteps = [];
     this.cachedStackFrameInTest = undefined;
 
     wsEvents.rtr.testBefore(mapSuiteAndTest(this.testStartedAt, this.suite, this.test));

--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -28,6 +28,10 @@ const mapSuiteAndTest = (startedAt, suite, test) => {
 const mapArgs = (args) => {
   return args.map(a => {
     if (typeof a === "function") return a.toString();
+    if (typeof a === "object") {
+      if (a.constructor.name === 'Locator') return a.toString();
+      if (a.constructor.name === 'Secret') return a.toString();
+    } 
     return a;
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3541,6 +3541,12 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
+    "camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true
+    },
     "camelcase-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
@@ -9052,6 +9058,12 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ=",
       "dev": true
     },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
+      "dev": true
+    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
@@ -9945,6 +9957,15 @@
         "lower-case": "^1.1.1"
       }
     },
+    "node-emoji": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
+      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "dev": true,
+      "requires": {
+        "lodash.toarray": "^4.4.0"
+      }
+    },
     "node-environment-flags": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
@@ -10086,6 +10107,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
       "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -11059,6 +11086,84 @@
         "postcss": "^7.0.0"
       }
     },
+    "postcss-functions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
+      "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2",
+        "object-assign": "^4.1.1",
+        "postcss": "^6.0.9",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
+      "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
+      "dev": true,
+      "requires": {
+        "camelcase-css": "^2.0.1",
+        "postcss": "^7.0.18"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.18.tgz",
+          "integrity": "sha512-/7g1QXXgegpF+9GJj4iN7ChGF40sYuGYJ8WZu8DZWnmhQ/G36hfdk3q9LBJmoK+lZ+yzZ5KYpOoxq7LF1BxE8g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "postcss-load-config": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
@@ -11375,6 +11480,16 @@
         }
       }
     },
+    "postcss-nested": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.1.2.tgz",
+      "integrity": "sha512-9bQFr2TezohU3KRSu9f6sfecXmf/x6RXDedl8CHF6fyuyVW7UqgNMRdWMHZQWuFY6Xqs2NYk+Fj4Z4vSOf7PQg==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^5.0.0"
+      }
+    },
     "postcss-normalize-charset": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-4.0.1.tgz",
@@ -11583,6 +11698,12 @@
         "renderkid": "^2.0.1",
         "utila": "~0.4"
       }
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
+      "dev": true
     },
     "pretty-ms": {
       "version": "5.0.0",
@@ -11948,6 +12069,16 @@
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
         }
+      }
+    },
+    "reduce-css-calc": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.6.tgz",
+      "integrity": "sha512-+l5/qlQmdsbM9h6JerJ/y5vR5Ci0k93aszLNpCmbadC3nBcbRGmIBm0s9Nj59i22LvCjTGftWzdQRwdknayxhw==",
+      "dev": true,
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
       }
     },
     "regenerate": {
@@ -13636,6 +13767,58 @@
           "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tailwindcss": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.1.2.tgz",
+      "integrity": "sha512-mcTzZHXMipnQY9haB17baNJmBTkYYcC8ljfMdB9/97FfhKJIzlglJcyGythuQTOu7r/QIbLfZYYWZhAvaGj95A==",
+      "dev": true,
+      "requires": {
+        "autoprefixer": "^9.4.5",
+        "bytes": "^3.0.0",
+        "chalk": "^2.4.1",
+        "fs-extra": "^8.0.0",
+        "lodash": "^4.17.11",
+        "node-emoji": "^1.8.1",
+        "normalize.css": "^8.0.1",
+        "postcss": "^7.0.11",
+        "postcss-functions": "^3.0.0",
+        "postcss-js": "^2.0.0",
+        "postcss-nested": "^4.1.1",
+        "postcss-selector-parser": "^6.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "reduce-css-calc": "^2.1.6"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "moment": "^2.24.0",
     "sass": "^1.22.9",
     "sass-loader": "^7.1.0",
+    "tailwindcss": "^1.1.2",
     "vue": "^2.6.10",
     "vue-highlightjs": "^1.3.3",
     "vue-router": "^3.0.7",
@@ -66,11 +67,6 @@
     "rules": {},
     "parserOptions": {
       "parser": "babel-eslint"
-    }
-  },
-  "postcss": {
-    "plugins": {
-      "autoprefixer": {}
     }
   },
   "browserslist": [

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	"plugins": [
+ 		require('tailwindcss')('tailwind.js'),
+ 		require('autoprefixer')(),
+	]
+}

--- a/src/assets/tailwind.css
+++ b/src/assets/tailwind.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -3,7 +3,7 @@
     :class="{ 'StepContainer--selected': isSelected, 'StepContainer--failed': step.result === 'failed', 'StepContainer--passed': step.result === 'passed' }"
     @click="handleSelectStep(step)">
     <div class="StepWrapper" v-if="isMetaStep(step)">
-      <MetaStep :step="step" />
+      <MetaStep :step="step" :isOpened="isOpened" />
     </div>
 
     <div class="StepWrapper" v-else-if="isConsoleLogStep(step)">
@@ -186,7 +186,7 @@ import copyToClipboard from 'copy-text-to-clipboard';
 
 export default {
   name: 'Step',
-  props: ['step', 'selectedStep', 'isHovered', 'isSelected', 'error'],
+  props: ['step', 'selectedStep', 'isHovered', 'isSelected', 'isOpened', 'error'],
   components: {
     SendStep,
     ActionStep,
@@ -322,7 +322,6 @@ export default {
     &.comment {
       font-weight: bold;
       @apply text-blue-700 bg-gray-100;
-      box-shadow: none;
     }
     &.action {
       @apply bg-white;
@@ -341,7 +340,6 @@ export default {
       color: hsl(204, 86%, 53%);
       display: inline-block;
       vertical-align: bottom;
-      border-bottom: 1px solid;
       @apply text-blue-600 border-blue-400;
       padding: 0;
       white-space: nowrap;

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -2,7 +2,7 @@
   <div class="StepContainer" 
     :class="{ 'StepContainer--selected': isSelected, 'StepContainer--failed': step.result === 'failed', 'StepContainer--passed': step.result === 'passed' }"
     @click="handleSelectStep(step)">
-    <div class="StepWrapper StepWrapper--indent2" v-if="isMetaStep(step)">
+    <div class="StepWrapper" v-if="isMetaStep(step)">
       <MetaStep :step="step" />
     </div>
 
@@ -10,7 +10,7 @@
       <ConsoleLogStep :step="step" />
     </div>
 
-    <div class="StepWrapper StepWrapper--indent1" v-else-if="isCommentStep(step)">
+    <div class="StepWrapper" v-else-if="isCommentStep(step)">
       <div class="step comment">
           {{step.args[0]}}
       </div>
@@ -408,15 +408,7 @@ export default {
 .StepWrapper {
   padding: .2em 0 .2em 0;
 }
-.StepWrapper--indent1 {
-  padding-left: .4em;
-}
-.StepWrapper--indent2 {
-  padding-left: .8em;
-}
-.StepWrapper--indent3 {
-  padding-left: 1.2em;
-}
+
 
 .GenericStep {
 }

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -17,13 +17,10 @@
     </div>
 
     <div class="StepWrapper"    v-else-if="true">
-
-
-      <WaiterStep :step="step" v-if="isWaiterStep(step)" />
+      <GrabberStep :step="step" v-if="isGrabberStep(step)" />
+      <WaiterStep :step="step" v-else-if="isWaiterStep(step)" />
       <AssertionStep :step="step" v-else-if="isAssertionStep(step)" />
       <div class="step" :class="{ 
-        wait: isWaiterStep(step), 
-        grab: isGrabberStep(step), 
         tech: isTechnicalStep(step) }"
         v-else-if="true"
         >
@@ -162,6 +159,7 @@ import axios from 'axios';
 import {getSelectorString} from '../services/selector';
 
 import AssertionStep from './steps/AssertionStep';
+import GrabberStep from './steps/GrabberStep';
 import WaiterStep from './steps/WaiterStep';
 import ActionStep from './steps/ActionStep';
 import SendStep from './steps/SendStep';
@@ -192,6 +190,7 @@ export default {
   components: {
     SendStep,
     ActionStep,
+    GrabberStep,
     AssertionStep,
     SeeStep,
     DontSeeStep,
@@ -340,7 +339,8 @@ export default {
 
     .argument {
       color: hsl(204, 86%, 53%);
-      display: inline;
+      display: inline-block;
+      vertical-align: bottom;
       border-bottom: 1px solid;
       @apply text-blue-600 border-blue-400;
       padding: 0;

--- a/src/components/Step.vue
+++ b/src/components/Step.vue
@@ -2,18 +2,54 @@
   <div class="StepContainer" 
     :class="{ 'StepContainer--selected': isSelected, 'StepContainer--failed': step.result === 'failed', 'StepContainer--passed': step.result === 'passed' }"
     @click="handleSelectStep(step)">
-    
     <div class="StepWrapper StepWrapper--indent2" v-if="isMetaStep(step)">
       <MetaStep :step="step" />
     </div>
 
-    <div class="StepWrapper StepWrapper--indent1" v-else-if="isCommentStep(step)">
-      <CommentStep :step="step" />
-    </div>
-
-    <div class="StepWrapper StepWrapper--indent3" v-else-if="isConsoleLogStep(step)">
+    <div class="StepWrapper" v-else-if="isConsoleLogStep(step)">
       <ConsoleLogStep :step="step" />
     </div>
+
+    <div class="StepWrapper StepWrapper--indent1" v-else-if="isCommentStep(step)">
+      <div class="step comment">
+          {{step.args[0]}}
+      </div>
+    </div>
+
+    <div class="StepWrapper"    v-else-if="true">
+
+
+      <WaiterStep :step="step" v-if="isWaiterStep(step)" />
+      <AssertionStep :step="step" v-else-if="isAssertionStep(step)" />
+      <div class="step" :class="{ 
+        wait: isWaiterStep(step), 
+        grab: isGrabberStep(step), 
+        tech: isTechnicalStep(step) }"
+        v-else-if="true"
+        >
+        {{step.humanized}} 
+        <span v-for="arg of step.args" v-bind:key="arg" class="argument" >
+          {{ arg }} 
+        </span>
+      </div>
+    </div>
+<!-- 
+    <div class="StepWrapper StepWrapper--indent1" v-else-if="isWaiterStep(step)">
+      <WaitStep :step="step" />
+    </div>
+
+    <div class="StepWrapper StepWrapper--indent1" v-else-if="isGrabberStep(step)">
+      <GrabStep :step="step" />
+    </div>
+
+    <div class="StepWrapper StepWrapper--indent1" v-else-if="isAssertionStep(step)">
+      <AssertionStep :step="step" />
+    </div>
+
+    <div class="StepWrapper StepWrapper--indent1" v-else-if="isTechnicalStep(step)">
+      <TechnicalStep :step="step" />
+    </div> 
+    
 
     <div class="StepWrapper StepWrapper--indent3" v-else-if="stepNameIncludes('send')">
       <SendStep :step="step" />
@@ -25,10 +61,6 @@
 
     <div class="StepWrapper StepWrapper--indent3" v-else-if="stepNameStartsWith('scroll')">
       <ScrollStep :step="step" />
-    </div>
-
-    <div class="StepWrapper StepWrapper--indent3" v-else-if="stepNameStartsWith('wait')">
-      <WaitStep :step="step" />
     </div>
 
     <div class="StepWrapper StepWrapper--indent3" v-else-if="stepNameStartsWith('click')">
@@ -81,7 +113,7 @@
 
     <div class="StepWrapper StepWrapper--indent3" v-else-if="stepNameStartsWith('saveScreenshot')">
       <SaveScreenshotStep :step="step" />
-    </div>
+    </div>-
 
     <div v-else class="StepWrapper StepWrapper--indent3">
       <div class="GenericStep columns is-gapless">
@@ -94,7 +126,7 @@
           <span class="Step-argOther" v-if="step.args[1]">{{toStringOrNumber(step.args[1])}}</span>
         </div>
       </div>
-    </div>
+    </div>-->
 
     <div class="StepHoverContainer" v-if="isHovered && isCodeceptStep(step)">
       <div class="StepHoverContainer-content is-pulled-right has-background-white">
@@ -129,6 +161,9 @@
 import axios from 'axios';
 import {getSelectorString} from '../services/selector';
 
+import AssertionStep from './steps/AssertionStep';
+import WaiterStep from './steps/WaiterStep';
+import ActionStep from './steps/ActionStep';
 import SendStep from './steps/SendStep';
 import SeeStep from './steps/SeeStep';
 import DontSeeStep from './steps/DontSeeStep';
@@ -156,9 +191,12 @@ export default {
   props: ['step', 'selectedStep', 'isHovered', 'isSelected', 'error'],
   components: {
     SendStep,
+    ActionStep,
+    AssertionStep,
     SeeStep,
     DontSeeStep,
     WaitStep,
+    WaiterStep,
     ClickStep,
     AmOnPageStep,
     CookieStep,
@@ -176,6 +214,7 @@ export default {
     ConsoleLogStep
   },
   methods: {
+
     isAction(step) {
       return ['click', 'clickLink', 'fillField', 'selectOption'].includes(step.name);
     },
@@ -198,6 +237,33 @@ export default {
 
     isConsoleLogStep(step) {
       return step.type === 'console.log';
+    },
+
+    isActionStep(step) {
+      return true;
+    },
+
+    isAssertionStep(step) {
+      return step.name.startsWith('see') || step.name.startsWith('dontSee');
+    },
+
+    isWaiterStep(step) {
+      return step.name.startsWith('wait');
+    },
+
+    isGrabberStep(step) {
+      return step.name.startsWith('grab');
+    },
+
+
+    isTechnicalStep(step) {
+      return step.name.includes('Cookie') 
+        || step.name.startsWith('press')
+        || step.name.includes('Screenshot')
+        || step.name.startsWith('send')
+        || step.name.startsWith('execute')
+        || step.name.startsWith('scroll')
+        || step.name.startsWith('refresh');
     },
 
     stepNameStartsWith(methodName) {
@@ -248,12 +314,62 @@ export default {
 }
 </script>
 
-<style lang="scss" scoped>
+
+<style lang="scss">
+  .step {
+    color: #000;
+    @apply bg-white shadow p-1;
+
+    &.comment {
+      font-weight: bold;
+      @apply text-blue-700 bg-gray-100;
+      box-shadow: none;
+    }
+    &.action {
+      @apply bg-white;
+    }
+    &.assert {
+      @apply bg-green-100;
+    }
+    &.tech {
+      @apply text-gray-500 bg-gray-100;
+    }
+    &.wait {
+      @apply text-gray-500 bg-orange-200;
+    }
+
+    .argument {
+      color: hsl(204, 86%, 53%);
+      display: inline;
+      border-bottom: 1px solid;
+      @apply text-blue-600 border-blue-400;
+      padding: 0;
+      white-space: nowrap;
+      overflow-x: auto;      
+      margin-right: 10px;
+
+      &:nth-of-type(2) {
+        @apply text-orange-600 border-orange-600;
+      }
+      &:nth-of-type(3) {
+        @apply border-green-600 text-green-600;
+      }      
+      &:nth-of-type(4) {
+        @apply border-red-400;
+      }            
+    }
+
+
+  }
+
+
+
 .StepContainer {
   position: relative;
   cursor: pointer;
   font-size: 0.9rem;
-  font-family:  Inconsolata, monospace; 
+  font-family:  Inconsolata, monospace;
+  overflow: hidden; 
 }
 
 .StepContainer--selected {
@@ -261,11 +377,11 @@ export default {
 }
 
 .StepContainer--passed {
-  border-left: 4px solid hsl(141, 71%, 48%);
+  border-right: 4px solid hsl(141, 71%, 48%);
 }
 
 .StepContainer--failed {
-  border-left: 4px solid hsl(348, 100%, 61%);
+  border-right: 4px solid hsl(348, 100%, 61%);
 }
 
 .StepHoverContainer {

--- a/src/components/Test.vue
+++ b/src/components/Test.vue
@@ -38,8 +38,11 @@
           :key="step.title"
           @mouseover="setHoveredStep(step)"
           @mouseleave="unsetHoveredStep(step)"
+          @click="toggleSubsteps(step)"
+          :ref="step.section"
         >
           <step
+            :class="'ml-' + indentLevel(step)"
             :step="step"
             :isHovered="step === hoveredStep"
             :isSelected="step === selectedStep"
@@ -137,6 +140,11 @@ export default {
       return moment.unix(ts / 1000).fromNow();
     },
 
+    indentLevel(step) {
+      if (!step.section) return 0;
+      return step.section.split('_').length * 3;
+    },
+
     activateTab(tabname) {
       this.activeTab = tabname;
     },
@@ -154,6 +162,16 @@ export default {
     },
     trim(str) {
       return str.trim();
+    },
+    toggleSubsteps(step) {
+      if (step.type !== 'meta') return true;
+      if (!step.opens) return true;
+      for (const section in this.$refs) {
+        const els = this.$refs[section];
+        console.log(els);
+        if (section.startsWith(step.opens)) els.forEach(el => el.classList.toggle('hidden'));
+      }
+      // this.$refs.filter(el => )
     },
     setHoveredStep(step) {
       this.$store.commit('testRunPage/setHoveredStep', step);

--- a/src/components/steps/ActionStep.vue
+++ b/src/components/steps/ActionStep.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="ActoinStep step">
+    I {{step.humanized}} 
+    <span v-for="arg of step.args" v-bind:key="arg" class="argument">
+      {{ arg }}
+    </span>
+  </div>
+</template>
+
+<script>
+export default {
+    name: 'ActionStep',
+    props: ['step'],
+    methods: {
+      extractPathname(urlAsString) {
+        const url = new URL(urlAsString);
+        return url.pathname;
+      }
+    }
+}
+</script>
+
+<style>
+.AmOnPageStep {
+}
+
+
+</style>
+
+

--- a/src/components/steps/ActionStep.vue
+++ b/src/components/steps/ActionStep.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="ActoinStep step">
+  <div class="step">
     I {{step.humanized}} 
     <span v-for="arg of step.args" v-bind:key="arg" class="argument">
       {{ arg }}

--- a/src/components/steps/AssertionStep.vue
+++ b/src/components/steps/AssertionStep.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="step assert">
+
+    <i class="far fa-eye" v-if="!isNegative(step.name)"></i>
+    <i class="far fa-eye-slash" v-if="isNegative(step.name)"></i>
+
+    {{formatStep(step.humanized)}} 
+
+    <span v-for="arg of step.args" v-bind:key="arg" class="argument">
+      {{ arg }} 
+    </span>
+  </div>
+</template>
+
+<script>
+import {getSelectorString} from '../../services/selector';
+
+export default {
+    name: 'AssertionStep',
+    props: ['step'],
+    methods: {      
+      isNegative(stepName) {
+        return stepName.startsWith('dontSee')
+      },
+      formatSelector(sel) {
+        return getSelectorString(sel).label;
+      },
+      formatStep(stepName) {
+        return stepName.replace(/^(see|dont see)/, '');
+      }
+    }
+}
+</script>
+
+<style>
+</style>
+
+

--- a/src/components/steps/CommentStep.vue
+++ b/src/components/steps/CommentStep.vue
@@ -1,12 +1,7 @@
 <template>
-    <div class="CommentStep columns is-gapless has-text-info is-family-sans-serif">
-        <div class="column is-narrow">
-            <i class="CommentStep-icon far fa-comments"></i>
-        </div>
-        <div class="column">
-           {{step.args[0]}}
-        </div>
-    </div>
+  <div class="step CommentStep">
+      {{step.args[0]}}
+  </div>
 </template>
 
 <script>
@@ -15,20 +10,12 @@ export default {
     props: ['step']
 }
 </script>
-
 <style>
 .CommentStep {
   font-family: -apple-system,BlinkMacSystemFont,Lato,Helvetica Neue,sans-serif;
-  padding-top: 1rem;
-  font-size: 1rem;
   font-weight: bold;
+  @apply text-blue-500 bg-gray-100;  
 }
-
-.CommentStep-icon {
-  display: inline-block;
-  width: 1.5rem;
-}
-
 </style>
 
 

--- a/src/components/steps/ConsoleLogStep.vue
+++ b/src/components/steps/ConsoleLogStep.vue
@@ -1,13 +1,7 @@
 <template>
-    <div class="ConsoleLogStep columns is-gapless">
-        <div class="column is-3">
-            <b-tag rounded :class="{ 'is-danger': step.logEntry.type === 'error' }">
-                console {{step.logEntry.type}}
-            </b-tag>
-        </div>
-        <div class="column ellipsize">
+    <div class="ConsoleLogStep is-gapless" :class="{ error: step.logEntry.type === 'error' }">
+            <b>console.{{step.logEntry.type}}</b>
             {{step.logEntry.args}}
-        </div>
     </div>
 </template>
 
@@ -18,8 +12,14 @@ export default {
 }
 </script>
 
-<style>
+<style lang="scss">
 .ConsoleLogStep {
+
+    @apply bg-yellow-200;
+    &.error {
+        @apply bg-red-200;
+    } 
+
 }
 </style>
 

--- a/src/components/steps/GrabberStep.vue
+++ b/src/components/steps/GrabberStep.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="step grab">
+
+    {{step.humanized}}
+
+
+    <span v-for="arg of step.args" v-bind:key="arg" class="argument">
+      {{ formatSelector(arg) }} 
+    </span>
+     
+     <div>
+    <i class="fas fa-hand-holding"></i>
+        <b> {{step.returnValue}}</b>
+     </div>
+  </div>
+</template>
+
+<script>
+import {getSelectorString} from '../../services/selector';
+
+export default {
+    name: 'GrabberStep',
+    props: ['step'],
+    methods: {      
+      formatSelector(sel) {
+        return getSelectorString(sel).label;
+      },
+    }
+}
+</script>
+
+<style>
+</style>
+
+

--- a/src/components/steps/MetaStep.vue
+++ b/src/components/steps/MetaStep.vue
@@ -1,8 +1,9 @@
 <template>
-    <div class="MetaStep columns is-gapless">
+    <div class="step">
+    <i class="fas fa-chevron-down" :class="{ 'is-opened': isOpened }"></i>
         <strong class="StepMetaStep has-text-grey">
             {{actorFromMetaStep(step)}}
-        </strong>
+        </strong> 
         <strong class="StepMetaStep has-text-dark">
             {{methodFromMetaStep(step)}}
         </strong>
@@ -12,7 +13,7 @@
 <script>
 export default {
     name: 'MetaStep',
-    props: ['step'],
+    props: ['step','isOpened'],
     methods: {
         actorFromMetaStep(step) {
         if (step.actor) {
@@ -34,8 +35,12 @@ export default {
 </script>
 
 <style>
-.MetaStep {
+.MetaStep {    
   font-family: -apple-system,BlinkMacSystemFont,Lato,Helvetica Neue,sans-serif;
+}
+.step i {  transition: 0.5s all; }
+.is-opened {
+  transform: rotate(-90deg);
 }
 </style>
 

--- a/src/components/steps/MetaStep.vue
+++ b/src/components/steps/MetaStep.vue
@@ -1,15 +1,11 @@
 <template>
     <div class="MetaStep columns is-gapless">
-        <div class="column is-3 ellipsize">
-            <strong class="StepMetaStep has-text-grey">
-                {{actorFromMetaStep(step)}}
-            </strong>
-        </div>
-        <div class="column">
-            <strong class="StepMetaStep has-text-dark">
-                {{methodFromMetaStep(step)}}
-            </strong>
-        </div>
+        <strong class="StepMetaStep has-text-grey">
+            {{actorFromMetaStep(step)}}
+        </strong>
+        <strong class="StepMetaStep has-text-dark">
+            {{methodFromMetaStep(step)}}
+        </strong>
     </div>
 </template>
 

--- a/src/components/steps/WaiterStep.vue
+++ b/src/components/steps/WaiterStep.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="step wait">
+    <i class="far fa-hourglass"></i>{{formatStep(step.humanized)}} 
+    <span v-for="arg of step.args" v-bind:key="arg" class="argument">
+      {{ arg }} 
+    </span>
+  </div>
+</template>
+
+<script>
+import {getSelectorString} from '../../services/selector';
+
+export default {
+    name: 'WaiterStep',
+    props: ['step'],
+    methods: {      
+      formatSelector(sel) {
+        return getSelectorString(sel).label;
+      },
+      formatStep(stepName) {
+        return stepName.replace(/^wait /, '').replace(/^for /, '');
+      }
+    }
+}
+</script>
+
+<style>
+</style>
+
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import Vue from 'vue';
+import '@/assets/tailwind.css'
 import App from './App.vue';
 import Vuex from 'vuex';
 import VueRouter from 'vue-router';

--- a/src/store/modules/testrun-page.js
+++ b/src/store/modules/testrun-page.js
@@ -5,6 +5,7 @@ const testRunPage = {
     show: 'source',
     selectedStep: undefined,
     hoveredStep: undefined,
+    showSubsteps: true,
   },
   getters: {
     hoveredStep: state => {
@@ -18,12 +19,15 @@ const testRunPage = {
     },
     showSource: state => {
       return state.show === 'source';
-    }
+    },
+    showSubsteps: state => state.showSubsteps
   },
   mutations: {
     clearTests: (state) => {
       state.selectedStep = undefined;
     },
+
+    toggleSubsteps: (state) => state.showSubsteps = !state.showSubsteps,
 
     setSelectedStep: (state, selectedStep) => {
       if (!selectedStep) return;

--- a/tailwind.js
+++ b/tailwind.js
@@ -1,0 +1,7 @@
+module.exports = {
+  theme: {
+    extend: {}
+  },
+  variants: {},
+  plugins: []
+}


### PR DESCRIPTION
![Selection_585](https://user-images.githubusercontent.com/220264/64855233-1de39200-d628-11e9-95e6-d5a9cb5cbc33.png)

![Selection_586](https://user-images.githubusercontent.com/220264/64855215-13c19380-d628-11e9-82df-3c693bea3f76.png)

![substeps](https://user-images.githubusercontent.com/220264/64914035-a3b02c00-d753-11e9-9038-113d78e25556.gif)

This PR includes

###  Unification of steps. 

Motivation: we can't hardcode step names in the components. There are different helpers, different steps names, users can create their own helpers and step names. The only rule we have that there are next groups of tests:

* actions
* assertions
* waiters
* grabbers
* comments
* metasteps

Hardcoding look for the exact step will generate tons of issues for edge cases.

### Unified Arguments

This can be doubtable change, but because arguments can be long, short, and there are up to 3 argument, there should be a way to display them nicely no matter of an actual step being used.

In this approach,

 I use inline style for an argument and a color to show its position

* blue -> 1st argument
* orange -> 2nd
* green -> 3rd


This is discussible, but it brings a clean look to arguments.

### Nested MetaSteps

The hierarchical structure of a test is now shown in a report.
All actions from a metastep will be shown with an indentation.
Clicking on metastep will toggle actions. So for a long scenarios you can easily toggle them up and down.

### Using Tailwind CSS

Tailwind CSS provides sane base classes which can be combined to create unified look for components. Such as steps.