### PR TITLE
Webdriver support

### DIFF
--- a/bin/codepress.js
+++ b/bin/codepress.js
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
 const debug = require('debug')('codepress:codepress');
+
+// initialize CodeceptJS
+require('../lib/commands/init')();
 const path = require('path');
 const express = require('express');
 const app = express();
 const io = require('socket.io')();
-
-const {init} = require('../lib/commands/init');
 const api = require('../lib/api');
-
 const snapshotStore = require('../lib/model/snapshot-store');
 const scenarioStatusRepository = require('../lib/model/scenario-status-repository');
 
@@ -21,6 +21,7 @@ const AppDir = path.join(__dirname, '..', 'dist');
  */
 app.use(express.static(AppDir));
 app.use('/api', api);
+
 
 const proxyEvents = {
   'console.error': undefined,
@@ -88,7 +89,8 @@ io.on('connection', socket => {
 });
 
 (async function() {
-  await init();
+  
+
 
   // eslint-disable-next-line no-console
   debug(`Listening for websocket connections on port ${PORT}`);

--- a/example/codecept.webdriver.conf.js
+++ b/example/codecept.webdriver.conf.js
@@ -1,0 +1,30 @@
+exports.config = {
+  tests: './todomvc-tests/**/*_test.js',
+  output: './output',
+  helpers: {
+    WebDriver: {
+      url: 'http://localhost',
+      browser: 'chrome',
+    },
+
+    REST: {},
+
+    CustomHelper: {
+      require: './todomvc-tests/helpers/custom.helper.js'
+    }
+  },
+
+  // gherkin: {
+  //   features: './todomvc-tests/features/*.feature',
+  //   steps: [
+  //     './todomvc-tests/step-definitions/create-todos.steps.js'
+  //   ]
+  // },
+
+  include: {
+    TodosPage: './todomvc-tests/pages/todos.page.js'
+  },
+  bootstrap: null,
+  mocha: {},
+  name: 'codepress demo tests'
+}

--- a/lib/codeceptjs/console-recorder.helper.js
+++ b/lib/codeceptjs/console-recorder.helper.js
@@ -12,6 +12,7 @@ class ConsoleRecorderHelper extends Helper {
     const helper = this.helpers['Puppeteer']
     if (!helper) {
       debug('Puppeteer helper not found -> console error reporting is disabled');
+      return;
     }
     const page = helper.page
 

--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -101,7 +101,7 @@ class RealtimeReporterHelper extends Helper {
   }
 
   _getHelper() {
-    return this.helpers['Appium'] || this.helpers['Webdriver'] || this.helpers['Puppeteer'];
+    return this.helpers['Appium'] || this.helpers['WebDriver'] || this.helpers['WebDriverIO'] || this.helpers['Puppeteer'] || this.helpers['TestCafe'];
   }
 
   _mapStep({testStartedAt, id, step, snapshot, returnValue}) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -1,67 +1,35 @@
+const commander = require('commander');
+const codeceptjsFactory = require('../model/codeceptjs-factory');
 const fs = require('fs');
 const path = require('path');
 
-var mkdir = function(dir) {
-	// making directory without exception if exists
-	try {
-		fs.mkdirSync(dir, 0755);
-	} catch(e) {
-		if(e.code != "EEXIST") {
-			throw e;
-		}
-	}
-};
-
-const copy = function(src, dest) {
-	var oldFile = fs.createReadStream(src);
-	var newFile = fs.createWriteStream(dest);
-	oldFile.pipe(newFile);
-};
-
-const copyDir = function(src, dest) {
-	mkdir(dest);
-	var files = fs.readdirSync(src);
-	for(var i = 0; i < files.length; i++) {
-		var current = fs.lstatSync(path.join(src, files[i]));
-		if(current.isDirectory()) {
-			copyDir(path.join(src, files[i]), path.join(dest, files[i]));
-		} else if(current.isSymbolicLink()) {
-			var symlink = fs.readlinkSync(path.join(src, files[i]));
-			fs.symlinkSync(symlink, path.join(dest, files[i]));
-		} else {
-			copy(path.join(src, files[i]), path.join(dest, files[i]));
-		}
-	}
-};
-
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
-
-const init = async () => {
-	console.log('Initializing codepress...')
-			
-	// Check if current directory is a codeceptjs directory
-    if (!fs.existsSync(path.join(process.cwd(), 'codecept.conf.js'))) {
-        console.log('Not a codeceptjs project (no codecept.conf.js found)');
-        process.exit(1);
-    }
-
-	// TODO Should also get rid of this when running in process
-	// Install deps
-	// try {
-	// 	const sio = require(path.join(process.cwd(), 'node_modules', 'socket.io-client'));
-	// } catch (_) {
-	// 	console.log('Installing socket.io-client ...')
-	// 	await exec('npm i socket.io-client')
-	// }
-
-    // Copy support files to current directory
-    // console.log('Copying support files to _codepress...')
-	// copyDir(path.join(__dirname, '..', 'codeceptjs'), path.join(process.cwd(), '_codepress'));
+module.exports = () => {
+	const program = new commander.Command();
+	program.version(JSON.parse(fs.readFileSync(`${__dirname}/../../package.json`, 'utf8')).version);
+	program
+		// codecept-only options
+		.option('--steps', 'show step-by-step execution')
+		.option('--debug', 'output additional information')
+		.option('--verbose', 'output internal logging information')
+		.option('-o, --override [value]', 'override current config options')
+		.option('-c, --config [file]', 'configuration file to be used')
+		.option('--features', 'run only *.feature files and skip tests')
+		.option('--tests', 'run only JS test files and skip features')
+		.option('-p, --plugins <k=v,k2=v2,...>', 'enable plugins, comma-separated');
 	
-	console.log('Initialization finished')
+	program.parse(process.argv);
+	
+	if (program.config) {
+		const configFile = program.config;
+		let configPath = path.join(process.cwd(), configFile);
+		if (!fs.lstatSync(configPath).isDirectory()) {
+			codeceptjsFactory.setConfigFile(path.basename(configPath));
+			configPath = path.dirname(configPath);
+		}
+		process.chdir(configPath);
+		codeceptjsFactory.setRootDir(configPath);
+	}
+	
+	codeceptjsFactory.create({}, program.opts());
 }
 
-module.exports = {
-    init,
-};

--- a/lib/model/codeceptjs-factory.js
+++ b/lib/model/codeceptjs-factory.js
@@ -2,7 +2,6 @@ const debug = require('debug')('codepress:codeceptjs-factory');
 const path = require('path');
 
 // codepress must be run in testproject dir
-const TestProject = process.cwd();
 
 const container = require('codeceptjs').container;
 const Codecept = require('codeceptjs').codecept;
@@ -12,6 +11,7 @@ const settingsRepository = require('./settings-repository');
 
 const defaultOpts = { };
 
+let TestProject = process.cwd();
 // current instance
 let instance;
 
@@ -58,7 +58,7 @@ module.exports = new class CodeceptjsFactory {
   }
 
   getInstance() {
-    if (!instance) instance = this.create(this._getDefaultConfig());
+    if (!instance) throw new Error('CodeceptJS is not initialized, initialize it with create()');
     return instance;
   }
 
@@ -66,8 +66,16 @@ module.exports = new class CodeceptjsFactory {
     return this.configFile;
   }
 
+  setConfigFile(configFile) {
+    this.configFile = configFile;
+  }  
+
   getRootDir() {
     return TestProject;
+  }
+
+  setRootDir(rootDir) {
+    TestProject = rootDir;
   }
 
   create(cfg = {}, opts = {}) {
@@ -83,7 +91,7 @@ module.exports = new class CodeceptjsFactory {
     container.clear();
     // create runner
     const codecept = new Codecept(cfg, opts = Object.assign(opts, defaultOpts));
-    
+   
     // initialize codeceptjs in current TestProject
     codecept.initGlobals(TestProject);
 
@@ -100,17 +108,24 @@ module.exports = new class CodeceptjsFactory {
     debug('Running hooks...');
     codecept.runHooks();
 
-    return {
+    instance = {
       config,
       codecept,
       container,
     }
+    return instance;
   }
 
   unrequireFile(filePath) {
     filePath = path.join(this.getRootDir(), filePath);
-    if (require.cache[require.resolve(filePath)]) {
-      delete require.cache[require.resolve(filePath)];
+    let modulePath;
+    try {
+      modulePath = require.resolve(filePath);
+    } catch (err) {
+      return;
+    }
+    if (require.cache[modulePath]) {
+      delete require.cache[modulePath];
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2040,6 +2040,46 @@
       "integrity": "sha512-Xn/+vdm9CjuC9p3Ae+lTClNutrVhsXpzxvoTXXtoys6kVRX9FkueSUAqSWAyZntmVLlR4DosBV4pH8y5Z/HbUw==",
       "dev": true
     },
+    "@wdio/config": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.12.1.tgz",
+      "integrity": "sha512-8pZOA0yInNlztcixftf9U4Cc/GSC5b8X2VfWhdhlr0IWekJ5HJ4l6UsLaIRaxGjIHsRsv4Zt2/dc52Q4f3SVrw==",
+      "dev": true,
+      "requires": {
+        "@wdio/logger": "^5.12.1",
+        "deepmerge": "^4.0.0",
+        "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+          "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==",
+          "dev": true
+        }
+      }
+    },
+    "@wdio/logger": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.12.1.tgz",
+      "integrity": "sha512-KUmdS0Scj0T5UQGtcWFiQRqc0NpFLQ/vSvRxlDzzkoeGwwPINqTRkLT103KL7Lyitlm9uLfaFfYc2KSzynTung==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "loglevel": "^1.6.0",
+        "loglevel-plugin-prefix": "^0.8.4",
+        "strip-ansi": "^5.2.0"
+      }
+    },
+    "@wdio/repl": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-5.12.1.tgz",
+      "integrity": "sha512-/f8bWdqoSOYiZ3MJyiAmXrf9ezi6KTA3wHrpltRYJHFsni+LWEKprAoEhPROkj7OijRuSQqWHLLLYg/BOjOClg==",
+      "dev": true,
+      "requires": {
+        "@wdio/config": "^5.12.1"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
@@ -2465,6 +2505,82 @@
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
       "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
       "dev": true
+    },
+    "archiver": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        }
+      }
+    },
+    "archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -3046,6 +3162,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^3.0.1"
+      }
+    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
@@ -3310,6 +3435,12 @@
           "dev": true
         }
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4027,6 +4158,11 @@
           "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
           "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -4224,9 +4360,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.1.tgz",
+      "integrity": "sha512-UNgvDd+csKdc9GD4zjtkHKQbT8Aspt2jCBqNSPp53vAS0L1tS9sXB2TCEOPHJ7kt9bN/niWkYj8T3RQSoMXdSQ=="
     },
     "common-path-prefix": {
       "version": "1.0.0",
@@ -4253,6 +4389,50 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "compress-commons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.3.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "compressible": {
       "version": "2.0.17",
@@ -4767,6 +4947,37 @@
         "parse-json": "^4.0.0"
       }
     },
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.4.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
+    },
+    "crc32-stream": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
+      "dev": true,
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -4998,6 +5209,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
+      "dev": true
+    },
+    "css-value": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
+      "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
     },
     "css-what": {
@@ -5634,6 +5851,13 @@
         "lru-cache": "^4.1.5",
         "semver": "^5.6.0",
         "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+        }
       }
     },
     "ee-first": {
@@ -7128,6 +7352,12 @@
         }
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -7337,6 +7567,12 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
       "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -8858,6 +9094,47 @@
         "launch-editor": "^2.2.1"
       }
     },
+    "lazystream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -8997,10 +9274,28 @@
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "dev": true
+    },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz",
       "integrity": "sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==",
+      "dev": true
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -9012,6 +9307,18 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",
       "integrity": "sha1-Tpho1FJXXXUK/9NYyXlUPcIO1Xc="
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -9042,10 +9349,22 @@
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A=",
       "dev": true
     },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "dev": true
+    },
     "lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "lodash.zip": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
     "log-symbols": {
@@ -9060,6 +9379,12 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
       "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+      "dev": true
+    },
+    "loglevel-plugin-prefix": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz",
+      "integrity": "sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==",
       "dev": true
     },
     "loose-envify": {
@@ -12277,6 +12602,12 @@
       "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
       "dev": true
     },
+    "rgb2hex": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.1.9.tgz",
+      "integrity": "sha512-32iuQzhOjyT+cv9aAFRBJ19JgHwzQwbjUhH3Fj2sWW2EEGAW8fpFrDFP5ndoKDxJaLO06x1hE3kyuIFrUQtybQ==",
+      "dev": true
+    },
     "rgba-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
@@ -13601,6 +13932,19 @@
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
     },
+    "tar-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "dev": true,
+      "requires": {
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
@@ -13620,6 +13964,12 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15298,6 +15648,75 @@
         "defaults": "^1.0.3"
       }
     },
+    "webdriver": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-5.12.1.tgz",
+      "integrity": "sha512-ywHkwUjY3vB2aqZ8pRDJsdFKx/GeMKF3rHJzxLHbrssytu4BuPQUDssbULUT/UwNG7R3cD+amBiomjmkHf3a+Q==",
+      "dev": true,
+      "requires": {
+        "@wdio/config": "^5.12.1",
+        "@wdio/logger": "^5.12.1",
+        "deepmerge": "^4.0.0",
+        "lodash.merge": "^4.6.1",
+        "request": "^2.83.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
+          "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww==",
+          "dev": true
+        }
+      }
+    },
+    "webdriverio": {
+      "version": "5.12.5",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-5.12.5.tgz",
+      "integrity": "sha512-KTbhnN/GS7jVeIIeatC3O4aerFc+H1CQIY6DxELUsa7H5nOXj8Sejw0j0z3frxBGtdqYpAHPEZEPmJRtizVEsA==",
+      "dev": true,
+      "requires": {
+        "@wdio/config": "^5.12.1",
+        "@wdio/logger": "^5.12.1",
+        "@wdio/repl": "^5.12.1",
+        "archiver": "^3.0.0",
+        "css-value": "^0.0.1",
+        "grapheme-splitter": "^1.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.isobject": "^3.0.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.zip": "^4.2.0",
+        "resq": "^1.6.0",
+        "rgb2hex": "^0.1.0",
+        "serialize-error": "^4.1.0",
+        "webdriver": "^5.12.1"
+      },
+      "dependencies": {
+        "resq": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/resq/-/resq-1.6.0.tgz",
+          "integrity": "sha512-8A4CsNY52RoSU4rpSfnEGPK2mkMO9kz0hi+SYhbKnSq7AFYxZFPTb2C7u6aEchD3vzFjotuCLnDfS81K/UsAmg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1"
+          }
+        },
+        "serialize-error": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
+          "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.3.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
+    },
     "webpack": {
       "version": "4.28.4",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.28.4.tgz",
@@ -15472,6 +15891,12 @@
           "version": "6.2.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.1.tgz",
           "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
         }
       }
@@ -17151,6 +17576,17 @@
           "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
           "dev": true
         }
+      }
+    },
+    "zip-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.2.tgz",
+      "integrity": "sha512-ykebHGa2+uzth/R4HZLkZh3XFJzivhVsjJt8bN3GvBzLaqqrUdRacu+c4QtnUgjkkQfsOuNE1JgLKMCPNmkKgg==",
+      "dev": true,
+      "requires": {
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "cheerio": "^1.0.0-rc.3",
     "chokidar": "^3.0.2",
     "codeceptjs": "^2.3.0",
+    "commander": "^3.0.1",
     "debug": "^4.1.1",
     "express": "^4.17.1",
     "lodash.clonedeep": "^4.5.0",
@@ -49,7 +50,8 @@
     "vue-router": "^3.0.7",
     "vue-socket.io": "^3.0.7",
     "vue-template-compiler": "^2.6.10",
-    "vuex": "^3.1.1"
+    "vuex": "^3.1.1",
+    "webdriverio": "^5.12.5"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
This PR does the following

* adds `commander` library to parse option
* support `codeceptjs` options like `--steps`, `--debug`, `--verbose`, `-c`
* initializes CodeceptJS on start with all passed options
* loads CodeceptJS from other directory or config file: `./bin/codepress.js -c example`
* added additional config `example/codecept.webdriver.conf.js`
* support WebDriver helper for running tests

```
./bin/codepress.js -c example/codecept.webdriver.conf.js
```

Fixes #53 
Fixes #49 

However, `DevTools` and `Headless` options in frontend should be disabled when running with WebDriver.
